### PR TITLE
Use symver prerelease notation for forked version

### DIFF
--- a/LicensesViewController.podspec
+++ b/LicensesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "LicensesViewController"
-  s.version          = "0.11.0+volvo3"
+  s.version          = "0.12.0-alpha.1.volvo"
   s.summary          = "Give credit where credit is due."
   s.description      = <<-DESC
                         Recursively finds all LICENSE.* files in a given directory and generates that can be displayed via Settings.bundle or the provided view controller.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Add the following to Package.swift
 let package = Package(
     ...
     dependencies: [
-    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.11.0+volvo3")
+    .package(name: "LicensesViewController", url: "https://github.com/volvogroup-mobility/LicenseGenerator-iOS", from: "0.12.0-alpha.1.volvo")
     ],
     targets: [
     .target(


### PR DESCRIPTION
Neither Cocoapods nor SPM take build info into consideration when determining updates. As a result a number of edge case issues have arisen. This PRs changes the versioning standard from adding build info to use pre-release info